### PR TITLE
Add "FinalHandler" to return the Response

### DIFF
--- a/src/FinalHandler.php
+++ b/src/FinalHandler.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ *
+ * This file is part of Telegraph for PHP.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @copyright 2016, Telegraph for PHP
+ *
+ */
+namespace Telegraph\Middleware;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ *
+ * Return the PSR-7 response.
+ *
+ * @package telegraph/middleware
+ *
+ */
+class FinalHandler
+{
+    /**
+     * Response
+     *
+     * @var ResponseInterface
+     *
+     * @access protected
+     */
+    protected $response;
+
+    /**
+     * __construct
+     *
+     * @param ResponseInterface $response The response
+     *
+     * @access public
+     */
+    public function __construct(ResponseInterface $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     *
+     * Return the PSR-7 Response.
+     *
+     * @param RequestInterface $request The HTTP request.
+     *
+     * @param callable $next The next middleware in the queue.
+     *
+     * @return ResponseInterface
+     *
+     */
+    public function __invoke(RequestInterface $request, callable $next)
+    {
+        return $this->response;
+    }
+}

--- a/tests/FinalHandlerTest.php
+++ b/tests/FinalHandlerTest.php
@@ -1,0 +1,20 @@
+<?php
+namespace Telegraph\Middleware;
+
+use Telegraph\Middleware\FakePhp;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\ServerRequestFactory;
+
+class FinalHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    public function test()
+    {
+        $response = new Response;
+        $handler = new FinalHandler($response);
+        $this->assertSame(
+            $response,
+            $handler(ServerRequestFactory::fromGlobals(), function () {})
+        );
+    }
+
+}


### PR DESCRIPTION
I'm not sure I'm understanding where the `Response` is "supposed to come from" with the PSR15 "lambda style" paradigm, but this seems possibly correct?
